### PR TITLE
Composer install with --no-interaction

### DIFF
--- a/symfony/z.yml
+++ b/symfony/z.yml
@@ -4,7 +4,7 @@ symfony: ~
 
 tasks:
     _symfony.build.composer_install: |
-        cd $(build.dir) && composer install --no-scripts --prefer-dist --optimize-autoloader --no-dev --no-suggest --no-progress
+        cd $(build.dir) && composer install --no-scripts --prefer-dist --optimize-autoloader --no-dev --no-suggest --no-progress --no-interaction
 
     _symfony.build.assets_install: |
         cd $(build.dir) && php $(path(symfony.root, symfony.console)) assets:install $(symfony.web) --env=$(target_env) --no-debug --symlink --relative;


### PR DESCRIPTION
* When building through Jenkins, interaction makes the build hang forever until someone spots the hanging build and kills it
* When building locally you theoretically could answer interactive questions being asked, but this should never happen on a build & deploy because that would indicate that there's something wrong that can't be resolved automatically